### PR TITLE
Add "Behave dark" theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Most themes should be available through the Community Themes pane in Obsidian's 
 [Obsidian + Nord](https://github.com/insanum/obsidian_nord) | A Nord-based theme for Obsidian, only supporting dark mode | ![](https://raw.githubusercontent.com/insanum/obsidian_nord/master/screen.png) | [insanum](https://github.com/insanum) |
 [Illusion Theme](https://github.com/ZaherAlMajed/Illusion-Theme.md) | A light theme for Obsidian. The theme is comfortable to the eye everything is a bit bigger and contrasted, combining dark & light themes gave it a unique touch. | ![](https://user-images.githubusercontent.com/54148795/125782571-78762279-c644-477a-9cdb-0666603190b9.png) | [Zaher Al Majed](https://github.com/ZaherAlMajed)|
 [Horizon](https://github.com/tylernguyen/obsidian-horizon) | Dark theme for Obsidian, inspired by the similarly named theme for VSCode. Compatible with Obsidian Desktop, Mobile, and Publish.  | ![Horizon Preview](https://raw.githubusercontent.com/tylernguyen/obsidian-horizon/main/assets/preview.png) | [Tyler Nguyen](https://github.com/tylernguyen)|
+[Behave dark](https://gitlab.com/chrismettal/obsidian-behave-dark) | A port of the eye friendly Behave dark theme by Christian Petersen, available for VSCode, FreeCAD, KiCAD, and now Obsidian! | ![BehaveDark](https://gitlab.com/Chrismettal/obsidian-behave-dark/-/raw/main/img/Screenshot.png) | [Chrismettal](https://gitlab.com/chrismettal)|
+
 
 # CSS Tweaks
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Most themes should be available through the Community Themes pane in Obsidian's 
 [Obsidian + Nord](https://github.com/insanum/obsidian_nord) | A Nord-based theme for Obsidian, only supporting dark mode | ![](https://raw.githubusercontent.com/insanum/obsidian_nord/master/screen.png) | [insanum](https://github.com/insanum) |
 [Illusion Theme](https://github.com/ZaherAlMajed/Illusion-Theme.md) | A light theme for Obsidian. The theme is comfortable to the eye everything is a bit bigger and contrasted, combining dark & light themes gave it a unique touch. | ![](https://user-images.githubusercontent.com/54148795/125782571-78762279-c644-477a-9cdb-0666603190b9.png) | [Zaher Al Majed](https://github.com/ZaherAlMajed)|
 [Horizon](https://github.com/tylernguyen/obsidian-horizon) | Dark theme for Obsidian, inspired by the similarly named theme for VSCode. Compatible with Obsidian Desktop, Mobile, and Publish.  | ![Horizon Preview](https://raw.githubusercontent.com/tylernguyen/obsidian-horizon/main/assets/preview.png) | [Tyler Nguyen](https://github.com/tylernguyen)|
-[Behave dark](https://gitlab.com/chrismettal/obsidian-behave-dark) | A port of the eye friendly Behave dark theme by Christian Petersen, available for VSCode, FreeCAD, KiCAD, and now Obsidian! | ![BehaveDark](https://gitlab.com/Chrismettal/obsidian-behave-dark/-/raw/main/img/Screenshot.png) | [Chrismettal](https://gitlab.com/chrismettal)|
+[Behave dark](https://gitlab.com/chrismettal/obsidian-behave-dark) | A port of the eye friendly `Behave` theme by Christian Petersen, available for `VSCode`, `FreeCAD`, `KiCAD`, and now `Obsidian`! | ![BehaveDark](https://gitlab.com/Chrismettal/obsidian-behave-dark/-/raw/main/img/Screenshot.png) | [Chrismettal](https://gitlab.com/chrismettal)|
 
 
 # CSS Tweaks


### PR DESCRIPTION
Hey,

please have a look at the just published [Behave dark theme](https://gitlab.com/Chrismettal/obsidian-behave-dark), an eye friendly, dark theme available for multiple tools like FreeCAD, KiCAD or VSCode.

If it's awesome enough for your list, feel free to merge it!