### PR TITLE
Create a snippet for static Vim caret

### DIFF
--- a/code/css-snippets/vim-static-caret.css
+++ b/code/css-snippets/vim-static-caret.css
@@ -1,0 +1,15 @@
+/* get more snippets at https://github.com/kmaasrud/awesome-obsidian */
+/* author: https://forum.obsidian.md/u/nenad/summary */
+/* Changes the Vim caret from a blinking one to a static one in the editor to reflect a more realistic Vim experience. */
+
+.cm-fat-cursor .CodeMirror-cursor {
+  visibility: visible !important;
+}
+
+.cm-animate-fat-cursor {
+  animation: none;
+}
+
+div.CodeMirror-cursors, div.CodeMirror-dragcursors, div.CodeMirror-secondarycursor {
+  visibility: visible !important;
+}


### PR DESCRIPTION
Instead of a blinking animated one, this one strips out the fanciness and we are left with the beautiful look of a static caret.