### PR TITLE
Inline code recoloring

### DIFF
--- a/code/css-snippets/recolor-inline-code.css
+++ b/code/css-snippets/recolor-inline-code.css
@@ -1,0 +1,15 @@
+/* Edit view */
+.cm-s-obsidian span.cm-inline-code,
+td code {
+  color: #9fef00 !important; /* Text color */
+}
+
+/* Reading view */
+.markdown-preview-view code {
+  color: #9fef00; /* Text color */
+}
+
+/* Prevents recoloring of code block snippets in reading view */
+.markdown-preview-view pre code {
+  color: initial; /* Reset text color */
+}


### PR DESCRIPTION
A simple bit of CSS that recolors inline code (not codeblocks). Works in both Editor and Reading modes. Also works with tables!

I created this for myself and thought others might like it as well.