### PR TITLE
Modified Stylish Blockquote by adding blockquote color 

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,9 @@ by [@Thery](https://forum.obsidian.md/u/Thery/summary)
 
 ![](media/css-snippets/stylish-blockquotes-1.png)
 
+![](https://github.com/aditya-an1l/awesome-obsidian/assets/140952269/c3636a80-1052-44a6-bb6d-55cb2121f7ea)
+
+
 [📁 stylish-blockquotes.css](code/css-snippets/stylish-blockquotes.css)
 
 ---

--- a/code/css-snippets/stylish-blockquotes.css
+++ b/code/css-snippets/stylish-blockquotes.css
@@ -5,11 +5,11 @@
 blockquote:before {
   font: 14px/20px italic Times, serif;
   content: "“";
-  /* Uncomment the following to add the Accent color to the “ symbol */
-  /* color: hsl(var(--accent-h), var(--accent-s), var(--accent-l)); */
   font-size: 3em;
   line-height: 0.1em;
   vertical-align: -0.4em;
+  /* Uncomment the following to add the Accent color to the “ symbol */
+  /* color: hsl(var(--accent-h), var(--accent-s), var(--accent-l)); */
 }
 blockquote p {
   display: inline;

--- a/code/css-snippets/stylish-blockquotes.css
+++ b/code/css-snippets/stylish-blockquotes.css
@@ -5,6 +5,8 @@
 blockquote:before {
   font: 14px/20px italic Times, serif;
   content: "“";
+  /* Uncomment the following to add the Accent color to the “ symbol */
+  /* color: hsl(var(--accent-h), var(--accent-s), var(--accent-l)); */
   font-size: 3em;
   line-height: 0.1em;
   vertical-align: -0.4em;

--- a/code/css-snippets/stylish-blockquotes.css
+++ b/code/css-snippets/stylish-blockquotes.css
@@ -8,8 +8,8 @@ blockquote:before {
   font-size: 3em;
   line-height: 0.1em;
   vertical-align: -0.4em;
-  /* Uncomment the following to add the Accent color to the “ symbol */
-  /* color: hsl(var(--accent-h), var(--accent-s), var(--accent-l)); */
+  
+  color: hsl(var(--accent-h), var(--accent-s), var(--accent-l));
 }
 blockquote p {
   display: inline;


### PR DESCRIPTION
Made changes in the `stylish-blockquotes.css`
By default, the colour of the blockquote is grey.

However, it would look good (or _stylish_ in a literal sense), if the block quote symbol had the same accent colour as that of the theme the user is using.

Something like this:

![image](https://github.com/kmaasrud/awesome-obsidian/assets/140952269/ca88c66e-3771-46a6-b6cf-dee4cd252506)

This is a minor change, but felt necessary for to add a _stylish_ element to the stylish blockquote snipet.

---

Here is an objective summary of what all changes are made:
[+] Added a line of code in the CSS snippet of Stylish Blockquotes (code/css-snippets/stylish-blockquotes.css).
[+] Added a preview in the README.md 