### PR TITLE
MacOS collapsing-sidebar.css fix

### DIFF
--- a/code/css-snippets/collapsing-sidebar.css
+++ b/code/css-snippets/collapsing-sidebar.css
@@ -24,3 +24,10 @@
 .side-dock-ribbon.mod-right.is-collapsed:not(:hover) {
   right: 0;
 }
+
+/* Optional Fix: sidebar icon below MacOS Window Controls */
+/*
+.clickable-icon {
+  margin-left: 2dvw;
+}
+*/

--- a/code/css-snippets/collapsing-sidebar.css
+++ b/code/css-snippets/collapsing-sidebar.css
@@ -27,7 +27,7 @@
 
 /* Optional Fix: sidebar icon below MacOS Window Controls */
 /*
-.clickable-icon {
+.sidebar-toggle-button > .clickable-icon {
   margin-left: 2dvw;
 }
 */


### PR DESCRIPTION
Added optional fix to move the sidebar icon out from under the window controls.