### PR TITLE
Add SeekLink to external tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ A curated list of awesome themes, plugins and more for [Obsidian](https://obsidi
 | [Obsidian For Business](https://github.com/tallguyjenks/Obsidian-For-Business) | A combination of a template vault with initial structure and some Microsoft Office VBA Macros to facilitate a powerful, extensible, and flexible plain text workflow using Microsoft Office and Obsidian For Business. | [Bryan Jenks](https://github.com/tallguyjenks) |
 | [Sourcegraph knowledge bases extension](https://github.com/bobheadxi/sourcegraph-knowledge-bases) | Browse Markdown knowledge bases (e.g. Obsidian vaults or Foam repositories) in Sourcegraph. | [Robert Lin](https://github.com/bobheadxi) |
 | [Obweb](https://github.com/chenyukang/obweb/) | Web applcation to view and edit files in an Obsidian vault. Optimized for mobile devices. | [Yukang Chen](https://github.com/chenyukang) |
+| [SeekLink](https://github.com/simonsysun/seeklink) | Local semantic search CLI for Obsidian-compatible Markdown vaults, with hybrid BM25/vector retrieval and line-anchored output for agents. | [Siyuan Sun](https://github.com/simonsysun) |
   
 ---
   


### PR DESCRIPTION
Adds SeekLink to the External Tools section.

SeekLink is a local semantic search CLI for Markdown and Obsidian-compatible vaults. It indexes `.md` files locally, combines BM25/vector/wikilink retrieval, and returns line-anchored results that can be read directly or used by coding agents.

Repo: https://github.com/simonsysun/seeklink