### PR TITLE
Add TopicSplit to External Tools > Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ A curated list of awesome themes, plugins and more for [Obsidian](https://obsidi
 | Name | Description | Credits |
 | :--: | :---------- | ------: |
 | [Obsidian For Business](https://github.com/tallguyjenks/Obsidian-For-Business) | A combination of a template vault with initial structure and some Microsoft Office VBA Macros to facilitate a powerful, extensible, and flexible plain text workflow using Microsoft Office and Obsidian For Business. | [Bryan Jenks](https://github.com/tallguyjenks) |
+| [TopicSplit](https://github.com/andrwspt/topicsplit) | Free offline semantic text grouper. Splits pasted text into topic segments by meaning, not word count. Perfect for breaking long articles into atomic notes. | [Andrew](https://github.com/andrwspt) |
 | [Sourcegraph knowledge bases extension](https://github.com/bobheadxi/sourcegraph-knowledge-bases) | Browse Markdown knowledge bases (e.g. Obsidian vaults or Foam repositories) in Sourcegraph. | [Robert Lin](https://github.com/bobheadxi) |
 | [Obweb](https://github.com/chenyukang/obweb/) | Web applcation to view and edit files in an Obsidian vault. Optimized for mobile devices. | [Yukang Chen](https://github.com/chenyukang) |
   


### PR DESCRIPTION
## Summary
Add **TopicSplit** to External Tools > Other — a free, offline semantic text grouper.

## Why it fits
- **MIT licensed**
- **Offline, single HTML file** — no server, no API key, no tracking
- **Solves a real Obsidian workflow pain**: splitting long articles into atomic notes
- **Open source & actively maintained**

## Links
- GitHub: https://github.com/andrwspt/topicsplit
- Live demo: https://andrwspt.github.io/topicsplit/
- License: MIT