### PR TITLE
Add TopicSplit to External Tools > Other

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,10 @@ A curated list of awesome themes, plugins and more for [Obsidian](https://obsidi
 | [Obsidian For Business](https://github.com/tallguyjenks/Obsidian-For-Business) | A combination of a template vault with initial structure and some Microsoft Office VBA Macros to facilitate a powerful, extensible, and flexible plain text workflow using Microsoft Office and Obsidian For Business. | [Bryan Jenks](https://github.com/tallguyjenks) |
 | [Sourcegraph knowledge bases extension](https://github.com/bobheadxi/sourcegraph-knowledge-bases) | Browse Markdown knowledge bases (e.g. Obsidian vaults or Foam repositories) in Sourcegraph. | [Robert Lin](https://github.com/bobheadxi) |
 | [Obweb](https://github.com/chenyukang/obweb/) | Web applcation to view and edit files in an Obsidian vault. Optimized for mobile devices. | [Yukang Chen](https://github.com/chenyukang) |
+| [TopicSplit](https://github.com/andrwspt/topicsplit) | Free offline semantic text grouper — split pasted text into topic segments by meaning. Perfect for breaking articles into atomic notes for Obsidian. 100% client-side, no server, no API key. | [andrwspt](https://github.com/andrwspt) |
   
 ---
-  
+
 </details>
 
 # Templates


### PR DESCRIPTION
## Description
Add TopicSplit to the External Tools > Other section.

TopicSplit is a free offline semantic text grouper that splits pasted text into topic segments by lexical cohesion (not word count). It's perfect for breaking articles into atomic notes for Obsidian.

- 100% client-side, no server, no API key
- MIT licensed
- Link: https://github.com/andrwspt/topicsplit

## Checklist
- [x] Entry follows the established table format
- [x] Added to the correct section (External Tools > Other)
- [x] Appended to the end of the section